### PR TITLE
Fix for title option

### DIFF
--- a/DatePicker.php
+++ b/DatePicker.php
@@ -222,7 +222,7 @@ class DatePicker extends \kartik\base\InputWidget
         $icon = ($type === 'picker') ? 'calendar' : 'remove';
         Html::addCssClass($options, 'input-group-addon kv-date-' . $icon);
         $icon = '<i class="glyphicon glyphicon-' . ArrayHelper::remove($options, 'icon', $icon) . '"></i>';
-        if (empty($options['title'])) {
+        if (!isset($options['title'])) {
             $title = ($type === 'picker') ? Yii::t('kvdate', 'Select date') : Yii::t('kvdate', 'Clear field');
             if ($title != false) {
                 $options['title'] = $title;


### PR DESCRIPTION
A variable is considered empty if it does not exist or if its value equals FALSE. Therefore, setting the title option to false was not having the desired effect of removing the title from the append/prepend components. Changed function to isset that determines if a variable is set and is not NULL. To summarize: empty(false) return true but !isset(false) returns false.