### PR TITLE
Wrong package version for dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,5 @@
         "psr-4": {
             "kartik\\date\\": ""
         }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.3.x-dev"
-        }
     }
 }


### PR DESCRIPTION
**Use case.**
I have a yii2 project with `minimal-stability: "dev"`. I want to install yii2-widgets via `composer require kartik-v/yii2-widgets "*"`.

**I want to see**
All widgets have last versions that equals `dev-master`.

**I actually observe**
The `kartik-v/yii2-widget-datepicker` widget has version `v1.3.2`.