### PR TITLE
Fixes for dynamic form throwing exception in JS

### DIFF
--- a/src/assets/js/bootstrap-datepicker.js
+++ b/src/assets/js/bootstrap-datepicker.js
@@ -34,7 +34,7 @@
     function alias(method, deprecationMsg) {
         return function () {
             if (deprecationMsg !== undefined) {
-                $.fn.datepicker.deprecated(deprecationMsg);
+                // $.fn.datepicker.deprecated(deprecationMsg);
             }
 
             return this[method].apply(this, arguments);


### PR DESCRIPTION
## Scope
This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made
Comment out deprecated function warnings that cause errors when using Yii2 DynamicForm modules
-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.