### PR TITLE
Correct DatePicker asset bundle registration

### DIFF
--- a/src/DatePicker.php
+++ b/src/DatePicker.php
@@ -478,7 +478,7 @@ class DatePicker extends InputWidget
         if (!empty($this->_langFile)) {
             DatePickerAsset::registerBundle($view, $this->bsVersion)->js[] = $this->_langFile;
         } else {
-            DatePickerAsset::register($view, $this->bsVersion);
+            DatePickerAsset::registerBundle($view, $this->bsVersion);
         }
         $id = $this->options['id'];
         $el = "jQuery('#" . $this->options['data-datepicker-source'] . "')";


### PR DESCRIPTION
There was an error while registering DatePickerAsset if `$this->_langFile` is empty:
Invalid Configuration – yii\base\InvalidConfigException

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

- Replaced `register()` with `registerBundle()` (L: 481)