### PR TITLE
Correct separator typo

### DIFF
--- a/src/DatePicker.php
+++ b/src/DatePicker.php
@@ -447,7 +447,7 @@ class DatePicker extends InputWidget
                         Html::textInput($this->name2, $this->value2, $this->options2);
                 }
                 $css = $isBs4 ? 'input-group-text' : 'input-group-addon';
-                $sep = Html::tag('span', $this->separator, ['class' => $css . ' kv-field-seperator']);
+                $sep = Html::tag('span', $this->separator, ['class' => $css . ' kv-field-separator']);
                 if ($isBs4) {
                     $sep = Html::tag('div', $sep, ['class' => 'input-group-append']);
                 }


### PR DESCRIPTION
Fixed typo in TYPE_RANGE separator class (kv-field-sepErator => kv-field-sepArator)

## Scope
This pull request includes a typo fix

## Changes
The following changes were made

- kv-field-seperator changed to kv-field-separator