### PR TITLE
Add the Greek language code in config.php

### DIFF
--- a/src/messages/config.php
+++ b/src/messages/config.php
@@ -7,7 +7,7 @@ return [
     'messagePath' => __DIR__,
     // array, required, list of language codes that the extracted messages
     // should be translated to. For example, ['zh-CN', 'de'].
-    'languages' => ['da', 'de', 'en', 'es', 'fr', 'hu', 'it', 'nl', 'pl', 'pt', 'ru', 'sv', 'th', 'vi', 'zh', 'gu', 'hi', 'uz', 'uz-Cy'],
+    'languages' => ['da', 'de', 'el', 'en', 'es', 'fr', 'hu', 'it', 'nl', 'pl', 'pt', 'ru', 'sv', 'th', 'vi', 'zh', 'gu', 'hi', 'uz', 'uz-Cy'],
     // string, the name of the function for translating messages.
     // Defaults to 'Yii::t'. This is used as a mark to find the messages to be
     // translated. You may use a string for single function name or an array for


### PR DESCRIPTION
## Scope
This pull request includes a

- [X] Translation

## Changes
The following changes were made:

- Although the Greek messages file exists, the corresponding language code is not there. This PR fixes it.

## Related Issues
Issue #196.